### PR TITLE
🐛 Fix iterating images data bugs, and chat ids

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,25 +89,31 @@ export const queryBard = async (message, ids = {}) => {
     }
 
     // Get important data, and update with important data if set to do so
-    const jsonChatData = JSON.parse(chatData)[4][0];
+    let jsonParsed = JSON.parse(chatData);
+    let jsonChatData = jsonParsed[4][0];
 
     let text = jsonChatData[1][0];
 
-    let images = jsonChatData[4].map((x) => {
+    let images = jsonChatData[4] && jsonChatData[4].map((x) => {
         return {
             tag: x[2],
-            url: x[0][5].match(/imgurl=([^&%]+)/)[1],
+            url: x[3][0],
+            source: {
+                url: x[1][0][0],
+                name: x[1][1],
+                favicon: x[1][3],
+            }
         };
-    }) ?? undefined;
+    }) 
 
     return {
         content: formatMarkdown(text, images),
         images: images,
         ids: {
             // Make sure kept in order, because using Object.keys() to query above
-            conversationID: jsonChatData[1][0],
-            responseID: jsonChatData[1][1],
-            choiceID: jsonChatData[4][0][0],
+            conversationID: jsonParsed[1][0],
+            responseID: jsonParsed[1][1],
+            choiceID: jsonChatData[0],
             _reqID: parseInt(ids._reqID ?? 0) + 100000,
         },
     };

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ export const queryBard = async (message, ids = {}) => {
     let images = jsonChatData[4] && jsonChatData[4].map((x) => {
         return {
             tag: x[2],
-            url: x[3][0],
+            url: x[3][0][0],
             source: {
                 url: x[1][0][0],
                 name: x[1][1],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bard-ai",
-    "version": "1.4.3",
+    "version": "1.4.4",
     "description": "A Reverse-Engineered Google Bard, Written in JS",
     "main": "index.js",
     "types": "@types/index.d.ts",


### PR DESCRIPTION
Bugs from https://github.com/EvanZhouDev/bard-ai/commit/9ae833e7247cfd646511a0ba82cd12e5387c7bd4 that I fixed in this commit; 

# Iterating Images Data Bugs
## Unable to iterate
This error occurs when there is no images replied from Bard;
```
    let images = jsonChatData[4].map((x) => {
                                 ^

TypeError: Cannot read properties of null (reading 'map')
```

## Unable to get image url. 
It returns an error when it tries to get the image url, it turns out that on x[0][5], the value was null.
```
url: x[0][5].match(/imgurl=([^&%]+)/)[1],
                         ^

TypeError: Cannot read properties of undefined (reading 'match')
```

## ✨ Proposing new feature!
In addition, I also proposing new data for the images returned from the `queryBard` function, and that is the image source, it contains the origin site, favicon, and page url the image was taken from.
```js
source: {
    url: 'https://support.apple.com/id-id/HT201296',
    name: 'support.apple.com',
    favicon: 'https://encrypted-tbn1.gstatic.com/favicon-tbn?q=tbn:ANd9GcSJqnLNI_iecnSYb17tgaI6s89jZ7Bwu_L_KKgAB8-3S1RFhvojRd-j9V3UlDmEM-m26mQwS9JKa1nvliUshzVUJzhzNIUBzQwlsTg'
  }
```

# Chat Ids Bugs
I notice that, the conversationID and responseID returned was not really the ID. This is the ID that is being returned;
```
    conversationID: 'Sure, here are some of the most popular Apple products',
    responseID: undefined,
```

It turns out because both conversationID and responseID, indexing from `const jsonChatData = JSON.parse(chatData)[4][0]` , however it should directly indexed from `JSON.parse(chatData)` (JSON array)
